### PR TITLE
Fix memory leak

### DIFF
--- a/src/desktop/desktopscrobbler.h
+++ b/src/desktop/desktopscrobbler.h
@@ -37,7 +37,7 @@ public:
     }
 
 private:
-    QFileSystemWatcher fileWatcher;
+    QFileSystemWatcher *fileWatcher;
     QFileSystemWatcher *dirWatcher;
     QQuickList<DesktopFile> desktopList;
 private slots:

--- a/src/keyeventfilter/keyeventfilter.cpp
+++ b/src/keyeventfilter/keyeventfilter.cpp
@@ -48,6 +48,7 @@ KeyEventFilter::KeyEventFilter(QQuickItem *parent)
 
 bool KeyEventFilter::eventFilter(QObject *object, QEvent *event)
 {
+    Q_UNUSED(object);
     // Discard events not related to keyboard
     if (event->type() != QEvent::KeyPress && event->type() != QEvent::KeyRelease)
         return false;

--- a/src/mixer/pulseaudiomixer.cpp
+++ b/src/mixer/pulseaudiomixer.cpp
@@ -115,6 +115,7 @@ void PulseAudioMixer::contextStateCallback(pa_context *c)
 
 void PulseAudioMixer::subscribeCallback(pa_context *c, pa_subscription_event_type_t t, uint32_t index)
 {
+    Q_UNUSED(index);
     switch (t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK) {
         case PA_SUBSCRIPTION_EVENT_SINK:
             pa_context_get_sink_info_list(c, [](pa_context *c, const pa_sink_info *i, int eol, void *ud) {


### PR DESCRIPTION
Changelog:
 - Fix memory leak
 - Use the `Q_UNUSED` macro for no unused parameter warnings
 - Fix bug with deletion of a desktop file and the list not being updated